### PR TITLE
Fix text color in syntax highlighting

### DIFF
--- a/src/renderer/src/lib/highlights.ts
+++ b/src/renderer/src/lib/highlights.ts
@@ -40,7 +40,7 @@ export const highlights = [
   syntaxHighlighting(
     HighlightStyle.define(specs, {
       scope: markdownLanguage,
-      all: { fontFamily: 'sans-serif !important' }
+      all: { fontFamily: 'sans-serif !important', color: "#000" }
     })
   ),
   syntaxHighlighting(


### PR DESCRIPTION
Add explicit black color to ensure consistent text visibility across themes.

🤖 Generated with [Claude Code](https://claude.ai/code)