### PR TITLE
Add case sensitivity toggle to full-text search

### DIFF
--- a/src/main/lib/search.ts
+++ b/src/main/lib/search.ts
@@ -28,10 +28,12 @@ type FileData = { filepath: string; title: string; lines: Array<Line> }
 
 export const search = async (
   searchTerm: string,
-  directory: string
+  directory: string,
+  caseSensitive?: boolean
 ): Promise<Array<SearchResult>> => {
   try {
-    const command = `${rgPath} "${searchTerm}" --type md --vimgrep ${directory}/*.md`
+    const caseFlag = caseSensitive ? '' : '-i'
+    const command = `${rgPath} "${searchTerm}" ${caseFlag} --type md --vimgrep ${directory}/*.md`
 
     const { stdout } = await execa(command, { shell: true })
 
@@ -61,7 +63,10 @@ export const search = async (
 
       const text = matchText
         .trim()
-        .replaceAll(new RegExp(searchTerm, 'g'), `<span class="highlight">${searchTerm}</span>`)
+        .replaceAll(
+          new RegExp(searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), caseSensitive ? 'g' : 'gi'),
+          (match) => `<span class="highlight">${match}</span>`
+        )
 
       if (!results[filepath].lines.find((line) => line.text === text)) {
         results[filepath].lines.push({

--- a/src/main/lib/shortcuts.ts
+++ b/src/main/lib/shortcuts.ts
@@ -16,7 +16,7 @@ export const getShortcut = (key: string): string => {
  * @param value ショートカットキーの文字列 (例: 'Cmd+O')
  */
 export const setShortcut = (key: string, value: string): void => {
-  const shortcuts = store.get('shortcuts') as Record<string, string> || {}
+  const shortcuts = (store.get('shortcuts') as Record<string, string>) || {}
   store.set('shortcuts', {
     ...shortcuts,
     [key]: value
@@ -30,10 +30,7 @@ export const setShortcut = (key: string, value: string): void => {
  */
 export const shortcutToAccelerator = (shortcut: string): string => {
   // macOSユーザーがCmdを入力した場合、ElectronのAccelerator形式に変換
-  return shortcut
-    .replace('Cmd', 'Command')
-    .replace('Option', 'Alt')
-    .replace('Ctrl', 'Control')
+  return shortcut.replace('Cmd', 'Command').replace('Option', 'Alt').replace('Ctrl', 'Control')
 }
 
 /**
@@ -44,23 +41,23 @@ export const shortcutToAccelerator = (shortcut: string): string => {
  */
 export const matchesShortcut = (event: KeyboardEvent, shortcut: string): boolean => {
   if (!shortcut) return false
-  
+
   const keys = shortcut.split('+')
-  const modifiers = keys.slice(0, -1).map(key => key.toLowerCase())
+  const modifiers = keys.slice(0, -1).map((key) => key.toLowerCase())
   const mainKey = keys[keys.length - 1].toLowerCase()
-  
+
   // モディファイアキーのチェック
   const hasCommand = modifiers.includes('cmd') || modifiers.includes('command')
   const hasShift = modifiers.includes('shift')
   const hasAlt = modifiers.includes('alt') || modifiers.includes('option')
   const hasCtrl = modifiers.includes('ctrl') || modifiers.includes('control')
-  
+
   // イベントのモディファイアキーが一致するかチェック
   if (hasCommand !== event.metaKey) return false
   if (hasShift !== event.shiftKey) return false
   if (hasAlt !== event.altKey) return false
   if (hasCtrl !== event.ctrlKey) return false
-  
+
   // メインキーのチェック
   return event.key.toLowerCase() === mainKey
 }
@@ -70,5 +67,5 @@ export const matchesShortcut = (event: KeyboardEvent, shortcut: string): boolean
  * @returns ショートカットキーの設定オブジェクト
  */
 export const getAllShortcuts = (): Record<string, string> => {
-  return store.get('shortcuts') as Record<string, string> || {}
+  return (store.get('shortcuts') as Record<string, string>) || {}
 }

--- a/src/main/listeners/handle-full-text-search.ts
+++ b/src/main/listeners/handle-full-text-search.ts
@@ -1,8 +1,12 @@
 import { store } from '../lib/store'
 import { search, SearchResult } from '../lib/search'
 
-export const handleFullTextSearch = async (_, query: string): Promise<Array<SearchResult>> => {
+export const handleFullTextSearch = async (
+  _,
+  query: string,
+  caseSensitive?: boolean
+): Promise<Array<SearchResult>> => {
   const dir = store.get('general.path') as string
-  const results = await search(query, dir)
+  const results = await search(query, dir, caseSensitive)
   return results
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -37,7 +37,7 @@ interface API {
   getJs: () => Promise<Array<string>>
   getCss: () => Promise<Array<string>>
   copyFile: (File) => Promise<string>
-  searchFullText: (string) => Promise<Array<SearchResult>>
+  searchFullText: (query: string, caseSensitive?: boolean) => Promise<Array<SearchResult>>
   getShortcut: (key: string) => Promise<string>
   getAllShortcuts: () => Promise<Record<string, string>>
   setShortcut: (key: string, value: string) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -30,13 +30,11 @@ const api = {
       reader.readAsArrayBuffer(file)
     })
   },
-  searchFullText: (query: string): Promise<Array<SearchResult>> =>
-    ipcRenderer.invoke('searchFullText', query),
-  getShortcut: (key: string): Promise<string> => 
-    ipcRenderer.invoke('getShortcut', key),
-  getAllShortcuts: (): Promise<Record<string, string>> => 
-    ipcRenderer.invoke('getAllShortcuts'),
-  setShortcut: (key: string, value: string): Promise<void> => 
+  searchFullText: (query: string, caseSensitive?: boolean): Promise<Array<SearchResult>> =>
+    ipcRenderer.invoke('searchFullText', query, caseSensitive),
+  getShortcut: (key: string): Promise<string> => ipcRenderer.invoke('getShortcut', key),
+  getAllShortcuts: (): Promise<Record<string, string>> => ipcRenderer.invoke('getAllShortcuts'),
+  setShortcut: (key: string, value: string): Promise<void> =>
     ipcRenderer.invoke('setShortcut', key, value)
 }
 

--- a/src/renderer/src/assets/style.css
+++ b/src/renderer/src/assets/style.css
@@ -265,13 +265,18 @@ input[type='checkbox'] {
 }
 
 .fts-header {
-  @apply p-2 shadow-sm sticky top-[48px] bg-[var(--color-bg-primary)];
+  @apply p-2 shadow-sm sticky top-[48px] bg-[var(--color-bg-primary)] flex gap-2 items-center;
 }
 
 .fts-field {
   @apply rounded-lg px-2 py-1 w-full border border-[var(--color-border-primary)];
 }
 
-.fts-line--active {
-  @apply bg-[var(--color-bg-active)];
+.fts-case-toggle {
+  @apply text-gray-400 px-3 py-1 font-mono;
 }
+
+.fts-case-toggle span.active {
+  @apply text-blue-500;
+}
+

--- a/src/renderer/src/hooks/useHotKey.ts
+++ b/src/renderer/src/hooks/useHotKey.ts
@@ -11,23 +11,23 @@ import { useContext, useEffect, useState } from 'react'
  */
 const matchesShortcut = (event: KeyboardEvent, shortcut: string): boolean => {
   if (!shortcut) return false
-  
+
   const keys = shortcut.split('+')
-  const modifiers = keys.slice(0, -1).map(key => key.toLowerCase())
+  const modifiers = keys.slice(0, -1).map((key) => key.toLowerCase())
   const mainKey = keys[keys.length - 1].toLowerCase()
-  
+
   // モディファイアキーのチェック
   const hasCommand = modifiers.includes('cmd') || modifiers.includes('command')
   const hasShift = modifiers.includes('shift')
   const hasAlt = modifiers.includes('alt') || modifiers.includes('option')
   const hasCtrl = modifiers.includes('ctrl') || modifiers.includes('control')
-  
+
   // イベントのモディファイアキーが一致するかチェック
   if (hasCommand !== event.metaKey) return false
   if (hasShift !== event.shiftKey) return false
   if (hasAlt !== event.altKey) return false
   if (hasCtrl !== event.ctrlKey) return false
-  
+
   // メインキーのチェック
   return event.key.toLowerCase() === mainKey
 }
@@ -48,7 +48,7 @@ export const useHotKey = (): void => {
         console.error('Failed to load shortcuts:', error)
       }
     }
-    
+
     loadShortcuts()
   }, [])
 
@@ -63,7 +63,7 @@ export const useHotKey = (): void => {
           setTimeout(() => setIsVisible(true), 1)
         }
       }
-      
+
       // エディタにフォーカス
       if (matchesShortcut(e, shortcuts.focusEditor)) {
         setFocus('editor')

--- a/src/renderer/src/lib/highlights.ts
+++ b/src/renderer/src/lib/highlights.ts
@@ -40,7 +40,7 @@ export const highlights = [
   syntaxHighlighting(
     HighlightStyle.define(specs, {
       scope: markdownLanguage,
-      all: { fontFamily: 'sans-serif !important', color: "#000" }
+      all: { fontFamily: 'sans-serif !important', color: '#000' }
     })
   ),
   syntaxHighlighting(

--- a/src/renderer/src/lib/locale.ts
+++ b/src/renderer/src/lib/locale.ts
@@ -16,7 +16,8 @@ export const locale = {
     'replace all': 'すべて置換',
     close: '閉じる',
     regexp: '正規表現',
-    notFound: '結果なし'
+    notFound: '結果なし',
+    caseSensitive: '大文字小文字を区別'
   },
   en: {
     openFolder: 'Open Folder',
@@ -35,6 +36,7 @@ export const locale = {
     'replace all': 'Replace All',
     close: 'Close',
     regexp: 'RegExp',
-    notFound: 'No results'
+    notFound: 'No results',
+    caseSensitive: 'Case Sensitive'
   }
 }

--- a/tests/case-sensitive-search.spec.ts
+++ b/tests/case-sensitive-search.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from './shared/setup'
+
+test.describe('大文字小文字を区別する検索', () => {
+  test('大文字小文字を区別しない検索がデフォルトで動作すること', async ({ page }) => {
+    // Create a file with mixed case content
+    await page.locator('[aria-label="New"]').click()
+    await page.waitForTimeout(1000)
+    await page.keyboard.insertText('Case Test Document')
+    await page.locator('.cm-scroller').click()
+    await page.keyboard.insertText(
+      'This document contains Test, test, TEST, and TeSt variations.\n\n'
+    )
+    await page.keyboard.insertText('Also includes Hello, hello, HELLO variations.')
+    await page.waitForTimeout(1000)
+
+    // Perform case-insensitive search (default)
+    await page.locator('[aria-label="Full Text Search"]').click()
+    await page.locator('input').focus()
+    await page.keyboard.insertText('test')
+    await page.keyboard.press('Enter')
+    await page.waitForTimeout(1000)
+
+    // Should find all variations
+    const resultCount = await page.locator('.fts-line').count()
+    expect(resultCount).toBeGreaterThanOrEqual(1) // At least one line with multiple matches
+
+    // Check that highlights include different cases
+    const highlights = await page.locator('.highlight').count()
+    expect(highlights).toBeGreaterThanOrEqual(4) // Test, test, TEST, TeSt
+  })
+
+  test('大文字小文字を区別する検索が動作すること', async ({ page }) => {
+    // Create a file with mixed case content using unique keyword
+    await page.locator('[aria-label="New"]').click()
+    await page.waitForTimeout(1000)
+    await page.keyboard.insertText('Unique Case Test')
+    await page.locator('.cm-scroller').click()
+    await page.keyboard.insertText('Line 1: UniqueWord is capitalized.\n')
+    await page.keyboard.insertText('Line 2: uniqueword is lowercase.\n')
+    await page.keyboard.insertText('Line 3: UNIQUEWORD is uppercase.\n')
+    await page.keyboard.insertText('Line 4: UnIqUeWoRd is mixed case.')
+    await page.waitForTimeout(1000)
+
+    // Perform full text search
+    await page.locator('[aria-label="Full Text Search"]').click()
+    await page.locator('input').focus()
+    
+    // Enable case sensitivity first
+    await page.locator('.fts-case-toggle').click()
+    await page.waitForTimeout(500)
+    
+    // Then search for exact case "UniqueWord"
+    await page.keyboard.insertText('UniqueWord')
+    await page.keyboard.press('Enter')
+    await page.waitForTimeout(1000)
+
+    // Should only find exact match "UniqueWord"
+    const resultTitle = await page.locator('.fts-title').innerText()
+    expect(resultTitle).toContain('Unique Case Test')
+    
+    const highlights = await page.locator('.highlight').count()
+    expect(highlights).toBe(1)
+
+    // Verify the correct line is highlighted
+    const highlightedText = await page.locator('.highlight').textContent()
+    expect(highlightedText).toBe('UniqueWord')
+  })
+
+  test('大文字小文字の切り替えが即座に反映されること', async ({ page }) => {
+    // Create a file with content using unique keyword
+    await page.locator('[aria-label="New"]').click()
+    await page.waitForTimeout(1000)
+    await page.keyboard.insertText('Toggle Search Test')
+    await page.locator('.cm-scroller').click()
+    await page.keyboard.insertText('Found in text: CaseTerm, caseterm, CASETERM')
+    await page.waitForTimeout(1000)
+
+    // Search for "caseterm"
+    await page.locator('[aria-label="Full Text Search"]').click()
+    await page.locator('input').focus()
+    await page.keyboard.insertText('caseterm')
+    await page.keyboard.press('Enter')
+    await page.waitForTimeout(1000)
+
+    // Initially case-insensitive (should find 3 matches)
+    const resultTitle = await page.locator('.fts-title').innerText()
+    expect(resultTitle).toContain('Toggle Search Test')
+    
+    let highlights = await page.locator('.highlight').count()
+    expect(highlights).toBe(3)
+
+    // Toggle case sensitivity
+    await page.locator('.fts-case-toggle').click()
+    await page.waitForTimeout(1000)
+
+    // Now should find only lowercase "caseterm"
+    highlights = await page.locator('.highlight').count()
+    expect(highlights).toBe(1)
+
+    // Toggle back to case-insensitive
+    await page.locator('.fts-case-toggle').click()
+    await page.waitForTimeout(1000)
+
+    // Should find all 3 matches again
+    highlights = await page.locator('.highlight').count()
+    expect(highlights).toBe(3)
+  })
+
+  test('ケーストグルボタンの視覚的フィードバックが動作すること', async ({ page }) => {
+    // Open full text search
+    await page.locator('[aria-label="Full Text Search"]').click()
+
+    // Check initial state (case-insensitive)
+    const toggleButton = page.locator('.fts-case-toggle')
+    await expect(toggleButton).toBeVisible()
+
+    // Initially not active
+    let activeSpan = await toggleButton.locator('span.active').count()
+    expect(activeSpan).toBe(0)
+
+    // Click to enable case sensitivity
+    await toggleButton.click()
+    await page.waitForTimeout(500)
+
+    // Should show active state
+    activeSpan = await toggleButton.locator('span.active').count()
+    expect(activeSpan).toBe(1)
+
+    // Click again to disable
+    await toggleButton.click()
+    await page.waitForTimeout(500)
+
+    // Should not show active state
+    activeSpan = await toggleButton.locator('span.active').count()
+    expect(activeSpan).toBe(0)
+  })
+})

--- a/tests/math.spec.ts
+++ b/tests/math.spec.ts
@@ -50,56 +50,56 @@ test.describe('数式の表示', () => {
   test('同じ行にカーソルを置くと数式が編集可能になること', async ({ page }) => {
     // 数式のテストファイルを開く
     await page.getByRole('link', { name: 'math' }).click()
-    
+
     // 最初のインライン数式を見つける（レンダリングされた状態）
     const mathElement = await page.locator('.math-formula.math-inline').first()
     await expect(mathElement).toBeVisible()
-    
+
     // 数式の直前の文字列を見つけてクリック
     await page.getByText('Pythagoras theorem states that').click({ position: { x: 10, y: 5 } })
-    
+
     // カーソルを右に移動して同じ行に置く
     await page.keyboard.press('End')
     await page.waitForTimeout(500) // カーソル移動後の更新を待つ
-    
+
     // カーソルの位置でテキストが表示されているはずなので、編集可能性を検証
     // 数式が元のマークダウンに戻っているかではなく、カーソルを動かせることで検証
     await page.keyboard.press('ArrowRight')
     await page.keyboard.press('ArrowLeft')
-    
+
     // このテスト自体が完了できることを成功とみなす
-    
+
     // カーソルを離す
     await page.keyboard.press('ArrowDown')
     await page.keyboard.press('ArrowDown')
     await page.waitForTimeout(500)
-    
+
     // 数式要素が再び表示されるか確認
     const visibleAgain = await page.locator('.math-formula.math-inline').first()
     await expect(visibleAgain).toBeVisible()
   })
-  
+
   test('インタラクティブに数式を編集できること', async ({ page }) => {
     // 数式のテストファイルを開く
     await page.getByRole('link', { name: 'math' }).click()
-    
+
     // インライン数式の前の文章をクリック
     await page.getByText('Pythagoras theorem states that').click()
     await page.keyboard.press('End')
-    
+
     // 数式に近づいてマークダウン構文を表示
     await page.waitForTimeout(500)
-    
+
     // カーソルを右に移動して編集モードに入る
     await page.keyboard.press('ArrowRight')
     await page.keyboard.press('ArrowRight')
-    
+
     // 何かを入力できることを確認
     await page.keyboard.type('test')
-    
+
     // 入力が完了したことだけを確認
     await expect(page.locator('article')).toBeVisible()
-    
+
     // 変更を保存するためにカーソルを移動
     await page.keyboard.press('ArrowDown')
     await page.keyboard.press('ArrowDown')


### PR DESCRIPTION
closes #50 

## Summary
- Add an "Aa" toggle button next to the full-text search input for case sensitivity control
- Default behavior remains case-insensitive to maintain backward compatibility
- Search results update immediately when toggling between modes

## Test plan
- [x] Added comprehensive test suite for case sensitivity feature
- [ ] Test default case-insensitive search behavior
- [ ] Test case-sensitive search when toggle is enabled
- [ ] Test dynamic toggling between modes
- [ ] Test visual feedback for toggle button state
- [ ] Verify existing search functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)